### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,13 @@ description = "An efficient implementation of the LessPass password generator."
 version     = "0.3.0"
 authors     = ["Grégoire Geis <git@gregoirege.is>"]
 
-homepage   = "https://github.com/71/lesspass.rs"
 repository = "https://github.com/71/lesspass.rs"
 readme     = "README.md"
 license    = "GPL-3.0-only"
 edition    = "2018"
+
+keywords = ["cli", "password", "generator"]
+categories = ["algorithms", "command-line-utilities"]
 
 [lib]
 name = "lesspass"


### PR DESCRIPTION
Your work on this tool is much appreciated! This PR makes a few improvements to Cargo.toml for compliance with the [C-METADATA](https://rust-lang.github.io/api-guidelines/documentation.html#cargotoml-includes-all-common-metadata-c-metadata) guideline.

- Added the fields `keywords` and `categories` to manifest. Please check whether these keywords are OK or whether more can apply.
- Removed `homepage`, which should point to a unique website of the project, not replicate the information in the repository field.