### PR TITLE
update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,7 +58,7 @@ version = "4.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0acbd8d28a0a60d7108d7ae850af6ba34cf2d1257fc646980e5f97ce14275966"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
  "is-terminal",
@@ -110,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -216,9 +222,8 @@ name = "lesspass"
 version = "0.4.1"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 2.4.2",
  "clap",
- "hmac",
  "pbkdf2",
  "rpassword",
  "sha2",
@@ -251,11 +256,12 @@ checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "pbkdf2"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
+ "hmac",
 ]
 
 [[package]]
@@ -316,7 +322,7 @@ version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b1fbb4dfc4eb1d390c02df47760bb19a84bb80b301ecc947ab5406394d8223e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,9 @@ path = "src/main.rs"
 required-features = ["default"]
 
 [dependencies]
-bitflags    = "1.2"
-hmac        = "0.12"
+bitflags    = "2.4"
 uint        = { version = "0.9", default-features = false }
-pbkdf2      = { version = "0.11", default-features = false }
+pbkdf2      = { version = "0.12", default-features = false, features = ["hmac"] }
 sha2        = { version = "0.10", default-features = false }
 
 atty      = { version = "0.2", optional = true }


### PR DESCRIPTION
I kind of liked how the non-`_hmac` pbkdf2 function reads a little more, but now you have to call `.expect` on the `Result` that it now returns (it used to unwrap it for us internally). Using the `pbkdf2_hmac` function requires the `hmac` feature to be enabled for the `pbkdf2` crate, which means we no longer _need_ the `hmac` crate since `pbkdf2` re-exports it.

I was going to run `cargo update` to update `Cargo.lock` as well, but quickly realized it would be a pain to properly review. Do let me know if you want me to commit that, too.