### PR TITLE
Renames numbers to digits and updates dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "lesspass"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "bitflags",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "lesspass"
 description = "An efficient implementation of the LessPass password generator."
-version     = "0.4.2"
+version     = "0.5.0"
 authors     = ["Grégoire Geis <opensource@gregoirege.is>"]
 
 repository = "https://github.com/71/lesspass.rs"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ USAGE:
 
 FLAGS:
     -L, --no-lower          Exclude lowercase characters.
-    -N, --no-numbers        Exclude numbers.
+    -D, --no-digits         Exclude digits.
     -S, --no-symbols        Exclude symbols.
     -U, --no-upper          Exclude uppercase characters.
     -h, --help              Prints help information

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,24 +41,24 @@ bitflags::bitflags! {
     pub struct CharacterSet: u8 {
         const Uppercase = 0b0001;
         const Lowercase = 0b0010;
-        const Numbers   = 0b0100;
+        const Digits    = 0b0100;
         const Symbols   = 0b1000;
 
         const Letters   = Self::Uppercase.bits() | Self::Lowercase.bits();
-        const All       = Self::Letters.bits() | Self::Numbers.bits() | Self::Symbols.bits();
+        const All       = Self::Letters.bits() | Self::Digits.bits() | Self::Symbols.bits();
     }
 }
 
 impl CharacterSet {
     const LOWERCASE: &'static str = "abcdefghijklmnopqrstuvwxyz";
     const UPPERCASE: &'static str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    const NUMBERS: &'static str = "0123456789";
+    const DIGITS: &'static str = "0123456789";
     const SYMBOLS: &'static str = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~";
 
     /// Returns a string that contains all the characters that may be used to
     /// generate a password.
     pub const fn get_characters(self) -> &'static str {
-        match (self.contains(Self::Lowercase), self.contains(Self::Uppercase), self.contains(Self::Numbers), self.contains(Self::Symbols)) {
+        match (self.contains(Self::Lowercase), self.contains(Self::Uppercase), self.contains(Self::Digits), self.contains(Self::Symbols)) {
             (true , true , true , true ) => "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~",
             (true , true , true , false) => "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
             (true , true , false, true ) => "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~",
@@ -75,7 +75,7 @@ impl CharacterSet {
             (false, true , false, false) => Self::UPPERCASE,
 
             (false, false, true , true ) => "0123456789!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~",
-            (false, false, true , false) => Self::NUMBERS,
+            (false, false, true , false) => Self::DIGITS,
             (false, false, false, true ) => Self::SYMBOLS,
 
             _ => ""
@@ -99,8 +99,8 @@ impl CharacterSet {
             sets[sets_len] = Self::UPPERCASE;
             sets_len += 1;
         }
-        if self.contains(Self::Numbers) {
-            sets[sets_len] = Self::NUMBERS;
+        if self.contains(Self::Digits) {
+            sets[sets_len] = Self::DIGITS;
             sets_len += 1;
         }
         if self.contains(Self::Symbols) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,9 +72,9 @@ pub struct Args {
     #[arg(short = 'U', long = "no-upper")]
     exclude_upper: bool,
 
-    /// Exclude numbers.
-    #[arg(short = 'N', long = "no-numbers")]
-    exclude_numbers: bool,
+    /// Exclude digits.
+    #[arg(short = 'D', long = "no-digits")]
+    exclude_digits: bool,
 
     /// Exclude symbols.
     #[arg(short = 'S', long = "no-symbols")]
@@ -116,7 +116,7 @@ fn run() -> Result<(), &'static str> {
         sha512,
         exclude_lower,
         exclude_upper,
-        exclude_numbers,
+        exclude_digits,
         exclude_symbols,
         return_entropy,
         print_fingerprint,
@@ -142,8 +142,8 @@ fn run() -> Result<(), &'static str> {
     if exclude_upper {
         charset.remove(CharacterSet::Uppercase);
     }
-    if exclude_numbers {
-        charset.remove(CharacterSet::Numbers);
+    if exclude_digits {
+        charset.remove(CharacterSet::Digits);
     }
     if exclude_symbols {
         charset.remove(CharacterSet::Symbols);

--- a/tests/blackbox.rs
+++ b/tests/blackbox.rs
@@ -45,7 +45,7 @@ fn t(
                         charset |= CharacterSet::Uppercase;
                     }
                     if digits {
-                        charset |= CharacterSet::Numbers;
+                        charset |= CharacterSet::Digits;
                     }
                     if symbols {
                         charset |= CharacterSet::Symbols;


### PR DESCRIPTION
In the upstream they have renamed the numbers field to digits ([see for example here](https://github.com/lesspass/lesspass/blob/main/containers/backend/api/migrations/0011_rename_numbers_password_digits.py)). This PR simply does that renaming and also updates the dependencies.

In my particular case I have also done the renaming in the [rockpass](https://gitlab.com/ogarcia/rockpass/-/commit/300e2463ba3c9faf015bb57fbe967b13c92647b8) or the [lesspass-client](https://gitlab.com/ogarcia/lesspass-client/-/commit/778793a50ddaa8c0772d57d112036624403929a2).